### PR TITLE
Fix Angular module structure

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -3,8 +3,10 @@ import { BrowserModule } from '@angular/platform-browser';
 import { AppComponent } from './app.component';
 import { RouterModule } from '@angular/router';
 import { routes } from './app.routes';
-import {CoreModule} from "./core/core.module";
-import {FullPageModule} from "./feature/full-page/full-page.module";
+import {CoreModule} from './core/core.module';
+import {FullPageModule} from './feature/full-page/full-page.module';
+import {MainPageModule} from './feature/main-page/main-page.module';
+import {SubPageModule} from './feature/sub-page/sub-page.module';
 
 @NgModule({
   declarations: [AppComponent],
@@ -12,7 +14,9 @@ import {FullPageModule} from "./feature/full-page/full-page.module";
     BrowserModule,
     RouterModule.forRoot(routes),
     CoreModule,
-    FullPageModule
+    FullPageModule,
+    MainPageModule,
+    SubPageModule
   ],
   providers: [],
   bootstrap: [AppComponent]

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -8,7 +8,7 @@ export const routes: Routes = [
   },
   {
     path: '',
-    redirectTo: '',
+    redirectTo: 'full-page',
     pathMatch: 'full'
   }
 ];

--- a/src/app/feature/full-page/full-page.module.ts
+++ b/src/app/feature/full-page/full-page.module.ts
@@ -2,6 +2,8 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FullPageComponent } from './full-page.component';
 import { RouterModule, Routes } from '@angular/router';
+import { MainPageModule } from '../main-page/main-page.module';
+import { SubPageModule } from '../sub-page/sub-page.module';
 
 const routes: Routes = [
   { path: ':topic', component: FullPageComponent },
@@ -11,6 +13,11 @@ const routes: Routes = [
 @NgModule({
   declarations: [FullPageComponent],
   exports: [FullPageComponent],
-  imports: [CommonModule, RouterModule.forChild(routes)]
+  imports: [
+    CommonModule,
+    RouterModule.forChild(routes),
+    MainPageModule,
+    SubPageModule
+  ]
 })
 export class FullPageModule {}

--- a/src/app/feature/main-page/main-page.module.ts
+++ b/src/app/feature/main-page/main-page.module.ts
@@ -1,0 +1,10 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MainPageComponent } from './main-page.component';
+
+@NgModule({
+  declarations: [MainPageComponent],
+  exports: [MainPageComponent],
+  imports: [CommonModule]
+})
+export class MainPageModule {}

--- a/src/app/feature/sub-page/sub-page.module.ts
+++ b/src/app/feature/sub-page/sub-page.module.ts
@@ -1,0 +1,10 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { SubPageComponent } from './sub-page.component';
+
+@NgModule({
+  declarations: [SubPageComponent],
+  exports: [SubPageComponent],
+  imports: [CommonModule]
+})
+export class SubPageModule {}


### PR DESCRIPTION
## Summary
- set default route to `full-page`
- register new `MainPageModule` and `SubPageModule`
- expose feature modules from `AppModule`
- include feature modules in `FullPageModule`

## Testing
- `npx tsc -p tsconfig.app.json --noEmit` *(fails: Cannot find module '@angular/core')*

------
https://chatgpt.com/codex/tasks/task_e_684896ec972c8325ad725175b84d0766