### PR TITLE
Remove standalone configuration from components

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -4,7 +4,7 @@ import { AppComponent } from './app.component';
 describe('AppComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [AppComponent],
+      declarations: [AppComponent],
     }).compileComponents();
   });
 

--- a/src/app/feature/full-page/full-page.component.spec.ts
+++ b/src/app/feature/full-page/full-page.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { FullPageComponent } from './full-page.component';
+import { FullPageModule } from './full-page.module';
 
 describe('FullPageComponent', () => {
   let component: FullPageComponent;
@@ -8,7 +9,7 @@ describe('FullPageComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [FullPageComponent]
+      imports: [FullPageModule]
     })
     .compileComponents();
     

--- a/src/app/feature/main-page/main-page.component.spec.ts
+++ b/src/app/feature/main-page/main-page.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { MainPageComponent } from './main-page.component';
+import { MainPageModule } from './main-page.module';
 
 describe('MainPageComponent', () => {
   let component: MainPageComponent;
@@ -8,7 +9,7 @@ describe('MainPageComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [MainPageComponent]
+      imports: [MainPageModule]
     })
     .compileComponents();
     

--- a/src/app/feature/main-page/main-page.component.ts
+++ b/src/app/feature/main-page/main-page.component.ts
@@ -2,9 +2,7 @@ import { Component } from '@angular/core';
 
 @Component({
   selector: 'app-main-page',
-  imports: [],
   templateUrl: './main-page.component.html',
-  standalone: true,
   styleUrl: './main-page.component.css'
 })
 export class MainPageComponent {

--- a/src/app/feature/sub-page/sub-page.component.spec.ts
+++ b/src/app/feature/sub-page/sub-page.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SubPageComponent } from './sub-page.component';
+import { SubPageModule } from './sub-page.module';
 
 describe('SubPageComponent', () => {
   let component: SubPageComponent;
@@ -8,7 +9,7 @@ describe('SubPageComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [SubPageComponent]
+      imports: [SubPageModule]
     })
     .compileComponents();
     

--- a/src/app/feature/sub-page/sub-page.component.ts
+++ b/src/app/feature/sub-page/sub-page.component.ts
@@ -2,7 +2,6 @@ import { Component } from '@angular/core';
 
 @Component({
   selector: 'app-sub-page',
-  imports: [],
   templateUrl: './sub-page.component.html',
   styleUrl: './sub-page.component.css'
 })


### PR DESCRIPTION
## Summary
- remove `standalone` configuration from MainPageComponent
- tidy SubPageComponent decorator
- update specs to import feature modules instead of components
- fix AppComponent spec to use declarations

## Testing
- `npm test` *(fails: `lifestyle-iwp-2025.github.io/node_modules/.bin/ng: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6848985f40ec83259b91be7383fd4c02