### PR TITLE
Add navbar module

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,1 +1,2 @@
+<app-navbar></app-navbar>
 <app-full-page></app-full-page>

--- a/src/app/core/core.module.ts
+++ b/src/app/core/core.module.ts
@@ -1,9 +1,13 @@
 import { NgModule } from '@angular/core';
 import { ConfigService } from './config.service';
 import { HttpClientModule } from '@angular/common/http';
+import { CommonModule } from '@angular/common';
+import { NavbarModule } from './navbar/navbar.module';
 
 @NgModule({
-  imports: [HttpClientModule],
+  declarations: [],
+  imports: [HttpClientModule, CommonModule, NavbarModule],
+  exports: [NavbarModule],
   providers: [ConfigService]
 })
 export class CoreModule {}

--- a/src/app/core/navbar/navbar.component.css
+++ b/src/app/core/navbar/navbar.component.css
@@ -1,0 +1,23 @@
+.navbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 1rem;
+}
+
+.logo {
+  height: 40px;
+}
+
+.nav-links {
+  list-style: none;
+  display: flex;
+  gap: 1rem;
+  margin: 0;
+  padding: 0;
+}
+
+.nav-links li a {
+  text-decoration: none;
+  color: inherit;
+}

--- a/src/app/core/navbar/navbar.component.html
+++ b/src/app/core/navbar/navbar.component.html
@@ -1,0 +1,8 @@
+<nav class="navbar">
+  <img class="logo" src="favicon.ico" alt="IWP Logo" />
+  <ul class="nav-links">
+    <li><a href="#">Home</a></li>
+    <li><a href="#">Studies</a></li>
+    <li><a href="#">Why IWP</a></li>
+  </ul>
+</nav>

--- a/src/app/core/navbar/navbar.component.spec.ts
+++ b/src/app/core/navbar/navbar.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NavbarComponent } from './navbar.component';
+import { CoreModule } from '../core.module';
+
+describe('NavbarComponent', () => {
+  let component: NavbarComponent;
+  let fixture: ComponentFixture<NavbarComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CoreModule]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(NavbarComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/core/navbar/navbar.component.ts
+++ b/src/app/core/navbar/navbar.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-navbar',
+  templateUrl: './navbar.component.html',
+  styleUrl: './navbar.component.css'
+})
+export class NavbarComponent {}

--- a/src/app/core/navbar/navbar.module.ts
+++ b/src/app/core/navbar/navbar.module.ts
@@ -1,0 +1,10 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { NavbarComponent } from './navbar.component';
+
+@NgModule({
+  declarations: [NavbarComponent],
+  exports: [NavbarComponent],
+  imports: [CommonModule]
+})
+export class NavbarModule {}


### PR DESCRIPTION
## Summary
- factor the navbar into its own `NavbarModule`
- rework `CoreModule` to expose `NavbarModule`

## Testing
- `npm test` *(fails: lifestyle-iwp-2025.github.io/node_modules/.bin/ng: not found)*


------
https://chatgpt.com/codex/tasks/task_e_68495e7071c48325a9a56abb3bdd3e3e