### PR TITLE
Fix text width overflow

### DIFF
--- a/src/app/feature/sturcture-block/sturcture-block.component.html
+++ b/src/app/feature/sturcture-block/sturcture-block.component.html
@@ -17,6 +17,8 @@
   font-family: "Jost", sans-serif;
   font-optical-sizing: auto;
   font-style: normal;
+  width: 50vw;
+  word-break: break-word;
 }
 
 .sturcture-block .grid {


### PR DESCRIPTION
## Summary
- set fixed width on sturcture block paragraph so text doesn't overflow

## Testing
- `node_modules/.bin/ng test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68591845d6b8832583abab2290978b51